### PR TITLE
Добавлены проверки в 10/10.2.9/tests

### DIFF
--- a/10/10.2.9/tests
+++ b/10/10.2.9/tests
@@ -21,3 +21,7 @@ output: НЕТ
 test #6
 input: 16
 output: НЕТ
+
+test #7
+input: 32
+output: ДА

--- a/10/10.2.9/tests
+++ b/10/10.2.9/tests
@@ -17,3 +17,7 @@ output: ДА
 test #5
 input: 0
 output: НЕТ
+
+test #6
+input: 16
+output: НЕТ


### PR DESCRIPTION
Тестов для https://stepik.org/lesson/567084/step/11?unit=561358 не достаточно:
система приняла решение #1427410097 с неверной маской `mask = 0b00010010` в которой включены **четвёртый** и первый биты (а не пятый и первый, как нужно).
Т.о. нужны ещё проверки, что в маске есть 1 именно в пятом разряде, а для 1 в четвёртом выдаётся негативный результат.
